### PR TITLE
Feat/psr 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           path: coverage/
       - run: composer test:e2e
       - run: composer phpstan:analyse
+      - run: composer lint
 
 workflows:
   test:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,19 +3,16 @@
   <description>Roots Coding Standards</description>
 
   <!-- Scan all files in directory -->
-  <file>.</file>
+  <file>src/</file>
 
   <!-- Scan only PHP files -->
   <arg name="extensions" value="php"/>
 
-  <!-- Ignore WordPress and Composer dependencies -->
-  <exclude-pattern>vendor/</exclude-pattern>
-
   <!-- Show colors in console -->
   <arg value="-colors"/>
 
-  <!-- Show sniff codes in all reports -->
-  <arg value="ns"/>
+  <!-- Show progress and sniff codes in all reports; -->
+  <arg value="nsp"/>
 
   <!-- Use PSR-2 and PSR-12 as a base -->
   <rule ref="PSR2"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,6 +17,7 @@
   <!-- Show sniff codes in all reports -->
   <arg value="ns"/>
 
-  <!-- Use PSR-12 as a base -->
+  <!-- Use PSR-2 and PSR-12 as a base -->
+  <rule ref="PSR2"/>
   <rule ref="PSR12"/>
 </ruleset>


### PR DESCRIPTION
- CircleCI: Run `composer lint`
- PHPCS: Check both PSR2 and PSR12 (because https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/PSR12/ruleset.xml doesn't extend from https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/PSR2/ruleset.xml)
- PHPCS: Show colors in console 
- PHPCS: Show progress (because some CI fails the build if no console output for too long and easier to know how many files are linted)
- PHPCS: Scan `src/` only (see: https://github.com/roots/wordpress-packager/pull/52#issuecomment-502923951)